### PR TITLE
Add resizing, overlaps, and edit mode 

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,6 @@
   "dependencies": {
     "@phosphor-icons/react": "^2.1.10",
     "@rsbuild/plugin-typed-css-modules": "^1.1.1",
-    "add-dev": "^1.0.0",
     "react": "^19.1.1",
     "react-dom": "^19.1.1",
     "typescript": "^5.9.2"

--- a/src/App.css
+++ b/src/App.css
@@ -20,6 +20,7 @@ body {
   display: flex;
   flex-flow: column nowrap;
   justify-content: center;
+  align-items: center;
 }
 
 .content h1 {
@@ -31,4 +32,22 @@ body {
   font-size: 1.5rem;
   font-weight: 400;
   opacity: 0.5;
+}
+
+.test-box {
+  width: 100%;
+  height: 100%;
+  background-color: slategray;
+  border-radius: 8px;
+  border: 4px solid darkgray;
+}
+
+.test-button {
+  width: 200px;
+  height: 40px;
+  color: white;
+  font-size: 1rem;
+  font-weight: 700;
+  cursor: pointer;
+  user-select: none;
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,30 +1,28 @@
-import React from "react";
+import React, { useState } from "react";
 import { Grid } from "./Grid";
 import Widget from "./Widget";
-import "./App.css";
+import styles from "./App.css";
 
 const TestBox = () => {
-  return (
-    <div
-      style={{
-        width: "100%",
-        height: "100%",
-        backgroundColor: "slategray",
-        borderRadius: "12px",
-        border: "4px solid darkgray",
-      }}
-    ></div>
-  );
+  return <div className={styles.testBox}></div>;
 };
 
 const App = () => {
-  return (
-    <div className="content">
-      <Grid width={24} height={12} showGrid={true}>
-        <Widget position={{ gridX: 9, gridY: 4 }}>
-          <TestBox></TestBox>
-        </Widget>
+  const [editing, setEditing] = useState(false);
 
+  return (
+    <div className={styles.content}>
+      {/*Temporary button for testing edit mode*/}
+      <button
+        className={[styles.testBox, styles.testButton].join(" ")}
+        onClick={() => {
+          setEditing(!editing);
+        }}
+      >
+        {editing ? "Disable" : "Enable"} Edit Mode
+      </button>
+
+      <Grid width={24} height={12} editing={editing}>
         <Widget
           size={{ width: 10, height: 1 }}
           position={{ gridX: 7, gridY: 2 }}
@@ -32,9 +30,13 @@ const App = () => {
           <TestBox></TestBox>
         </Widget>
 
+        <Widget position={{ gridX: 8, gridY: 4 }}>
+          <TestBox></TestBox>
+        </Widget>
+
         <Widget
-          size={{ width: 1, height: 1 }}
-          position={{ gridX: 7, gridY: 4 }}
+          size={{ width: 1, height: 4 }}
+          position={{ gridX: 15, gridY: 4 }}
           resizeable={false}
         >
           <TestBox></TestBox>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -12,7 +12,6 @@ const TestBox = () => {
         backgroundColor: "slategray",
         borderRadius: "12px",
         border: "4px solid darkgray",
-        // opacity: 0.75,
       }}
     ></div>
   );

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -25,7 +25,7 @@ const App = () => {
         <Widget size={{ width: 4, height: 4 }}>
           <TestBox></TestBox>
         </Widget>
-        <Widget size={{ width: 3, height: 2 }}>
+        <Widget size={{ width: 8, height: 1 }}>
           <TestBox></TestBox>
         </Widget>
       </Grid>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,10 +9,10 @@ const TestBox = () => {
       style={{
         width: "100%",
         height: "100%",
-        backgroundColor: "lightcoral",
+        backgroundColor: "slategray",
         borderRadius: "12px",
-        border: "4px solid pink",
-        opacity: 0.75,
+        border: "4px solid darkgray",
+        // opacity: 0.75,
       }}
     ></div>
   );
@@ -21,11 +21,20 @@ const TestBox = () => {
 const App = () => {
   return (
     <div className="content">
-      <Grid width={24} height={12}>
-        <Widget size={{ width: 4, height: 4 }}>
+      <Grid width={24} height={12} showGrid={true}>
+        <Widget position={{ gridX: 0, gridY: 2 }}>
           <TestBox></TestBox>
         </Widget>
+
         <Widget size={{ width: 8, height: 1 }}>
+          <TestBox></TestBox>
+        </Widget>
+
+        <Widget
+          size={{ width: 1, height: 1 }}
+          position={{ gridX: 7, gridY: 2 }}
+          resizeable={false}
+        >
           <TestBox></TestBox>
         </Widget>
       </Grid>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -22,17 +22,20 @@ const App = () => {
   return (
     <div className="content">
       <Grid width={24} height={12} showGrid={true}>
-        <Widget position={{ gridX: 0, gridY: 2 }}>
+        <Widget position={{ gridX: 9, gridY: 4 }}>
           <TestBox></TestBox>
         </Widget>
 
-        <Widget size={{ width: 8, height: 1 }}>
+        <Widget
+          size={{ width: 10, height: 1 }}
+          position={{ gridX: 7, gridY: 2 }}
+        >
           <TestBox></TestBox>
         </Widget>
 
         <Widget
           size={{ width: 1, height: 1 }}
-          position={{ gridX: 7, gridY: 2 }}
+          position={{ gridX: 7, gridY: 4 }}
           resizeable={false}
         >
           <TestBox></TestBox>

--- a/src/Drag.tsx
+++ b/src/Drag.tsx
@@ -11,19 +11,25 @@ type DragCallback = (x: number, y: number, dragging: boolean) => void;
 interface DragContextType {
   isDragging: boolean;
   activeItem?: HTMLElement;
+  dragStart: { x: number; y: number };
 }
 
 const DragContext = createContext<DragContextType>({
   isDragging: false,
   activeItem: null,
+  dragStart: { x: 0, y: 0 },
 });
 
 export function Draggable({
-  onDrag,
+  enabled = true,
+  onDrag = () => {},
+  onDragRelative = () => {},
   children,
 }: {
-  onDrag: DragCallback;
-  children: React.ReactNode;
+  enabled?: boolean;
+  onDrag?: DragCallback;
+  onDragRelative?: DragCallback;
+  children?: React.ReactNode;
 }) {
   const ctx = useContext(DragContext);
   const ref = useRef<HTMLElement>(null);
@@ -32,29 +38,40 @@ export function Draggable({
 
   function handleMouseDown(e: React.MouseEvent) {
     if (ctx.isDragging) return;
+    e.preventDefault();
 
     ctx.isDragging = true;
     ctx.activeItem = ref.current;
     const rect = ref.current.getBoundingClientRect();
+    ctx.dragStart = { x: rect.left, y: rect.top };
     setPosition({ x: rect.left, y: rect.top });
 
-    onDrag(position.x, position.y, ctx.isDragging);
+    onDrag(rect.left, rect.top, true);
+    onDragRelative(0, 0, true);
   }
 
   function handleMouseUp(e: React.MouseEvent) {
     if (!ctx.isDragging || ctx.activeItem !== ref.current) return;
+    e.preventDefault();
 
     ctx.isDragging = false;
     ctx.activeItem = null;
 
-    onDrag(position.x, position.y, ctx.isDragging);
+    onDrag(position.x, position.y, false);
+    onDragRelative(0, 0, false);
   }
 
   function handleMouseMove(e: React.MouseEvent) {
     if (!ctx.isDragging || ctx.activeItem !== ref.current) return;
     e.preventDefault();
     setPosition({ x: position.x + e.movementX, y: position.y + e.movementY });
-    onDrag(position.x, position.y, ctx.isDragging);
+
+    onDrag(position.x, position.y, true);
+    onDragRelative(
+      position.x - ctx.dragStart.x,
+      position.y - ctx.dragStart.y,
+      true,
+    );
   }
 
   useEffect(() => {
@@ -75,7 +92,8 @@ export function Draggable({
       style={{
         width: "100%",
         height: "100%",
-        cursor: "move",
+        cursor: "grab",
+        pointerEvents: enabled ? "auto" : "none",
       }}
       onMouseDown={handleMouseDown}
     >
@@ -83,23 +101,3 @@ export function Draggable({
     </div>
   );
 }
-
-// export default function DragHandler({
-//   onDrag,
-//   children,
-// }: {
-//   onDrag: DragCallback;
-//   children: React.ReactNode;
-// }) {
-//   return (
-//     <div>
-//       <DragContext
-//         value={{ isDragging: false, activeItem: null, onDrag: onDrag }}
-//       >
-//         {Children.map(children, (child) => (
-//           <Draggable>{child}</Draggable>
-//         ))}
-//       </DragContext>
-//     </div>
-//   );
-// }

--- a/src/Drag.tsx
+++ b/src/Drag.tsx
@@ -92,6 +92,9 @@ export function Draggable({
       style={{
         width: "100%",
         height: "100%",
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
         cursor: enabled ? "grab" : "default",
         // pointerEvents: enabled ? "auto" : "none",
       }}

--- a/src/Drag.tsx
+++ b/src/Drag.tsx
@@ -32,12 +32,12 @@ export function Draggable({
   children?: React.ReactNode;
 }) {
   const ctx = useContext(DragContext);
-  const ref = useRef<HTMLElement>(null);
+  const ref = useRef<HTMLDivElement>(null);
 
   const [position, setPosition] = useState({ x: 0, y: 0 });
 
   function handleMouseDown(e: React.MouseEvent) {
-    if (ctx.isDragging) return;
+    if (!enabled || ctx.isDragging) return;
     e.preventDefault();
 
     ctx.isDragging = true;
@@ -92,8 +92,8 @@ export function Draggable({
       style={{
         width: "100%",
         height: "100%",
-        cursor: "grab",
-        pointerEvents: enabled ? "auto" : "none",
+        cursor: enabled ? "grab" : "default",
+        // pointerEvents: enabled ? "auto" : "none",
       }}
       onMouseDown={handleMouseDown}
     >

--- a/src/Drag.tsx
+++ b/src/Drag.tsx
@@ -95,7 +95,7 @@ export function Draggable({
         display: "flex",
         alignItems: "center",
         justifyContent: "center",
-        cursor: enabled ? "grab" : "default",
+        cursor: enabled ? "grab" : "auto",
         // pointerEvents: enabled ? "auto" : "none",
       }}
       onMouseDown={handleMouseDown}

--- a/src/Grid.css
+++ b/src/Grid.css
@@ -24,12 +24,23 @@
   transition: padding 0.25s;
 }
 
+@keyframes fade-in {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+
 .grid-slot-inner {
+  /*opacity: 0;*/
   width: 100%;
   height: 100%;
   border: 1.5px solid #fff4;
   border-radius: 6px;
   transition: background-color 0.25s;
+  /*animation: fade-in var(--transition-time) ease-out forwards;*/
 }
 
 .grid-slot:hover {
@@ -74,8 +85,8 @@
   box-sizing: border-box;
   z-index: 1;
   opacity: 0.75;
-  /*background-color: #fff4;
-  border-radius: 12px;*/
+  background-color: #fff4;
+  border-radius: 12px;
 }
 
 .grid-item.resizing {
@@ -114,6 +125,7 @@
   transition:
     opacity var(--transition-time),
     transform var(--transition-time);
+  /*animation: fade-in var(--transition-time) ease-out forwards;*/
 }
 
 .resize:hover,

--- a/src/Grid.css
+++ b/src/Grid.css
@@ -56,13 +56,74 @@
 
 .grid-item {
   position: absolute;
+  display: flex;
+  align-items: center;
+  justify-content: center;
   width: 100%;
   height: 100%;
+
+  transition: transform 0.15s;
 }
 
-.grid-item.drag {
+.grid-item.resizing {
+  transition:
+    width 0.15s,
+    height 0.15s;
+  transition-timing-function: cubic-bezier(0.34, 1.56, 0.64, 1);
+}
+
+.grid-item.dragging {
+  transform: scale(1.05);
   transition:
     top 0.15s,
-    left 0.15s;
+    left 0.15s,
+    transform 0.15s;
   transition-timing-function: cubic-bezier(0.34, 1.56, 0.64, 1);
+  z-index: 99;
+}
+
+.resize {
+  background-color: white;
+  border-radius: 4px;
+  opacity: 0.75;
+  position: absolute;
+  transition:
+    opacity 0.15s,
+    transform 0.15s;
+}
+
+.resize:hover {
+  opacity: 1;
+  transform: scale(1.25);
+  transition:
+    opacity 0.15s,
+    transform 0.15s;
+}
+
+.resize-left,
+.resize-right {
+  width: 8px;
+  height: 32px;
+}
+
+.resize-left {
+  left: 8px;
+}
+
+.resize-right {
+  right: 8px;
+}
+
+.resize-up,
+.resize-down {
+  width: 32px;
+  height: 8px;
+}
+
+.resize-up {
+  top: 8px;
+}
+
+.resize-down {
+  bottom: 8px;
 }

--- a/src/Grid.css
+++ b/src/Grid.css
@@ -62,22 +62,28 @@
   width: 100%;
   height: 100%;
 
-  transition: transform 0.15s;
+  transition:
+    transform 0.15s,
+    opacity 0.15s;
 }
 
 .grid-item.resizing {
+  opacity: 0.75;
   transition:
     width 0.15s,
-    height 0.15s;
+    height 0.15s,
+    opacity 0.15s;
   transition-timing-function: cubic-bezier(0.34, 1.56, 0.64, 1);
 }
 
 .grid-item.dragging {
   transform: scale(1.05);
+  opacity: 0.75;
   transition:
     top 0.15s,
     left 0.15s,
-    transform 0.15s;
+    transform 0.15s,
+    opacity 0.15s;
   transition-timing-function: cubic-bezier(0.34, 1.56, 0.64, 1);
   z-index: 99;
 }
@@ -85,19 +91,20 @@
 .resize {
   background-color: white;
   border-radius: 4px;
-  opacity: 0.75;
+  opacity: 0.5;
   position: absolute;
   transition:
     opacity 0.15s,
     transform 0.15s;
 }
 
-.resize:hover {
-  opacity: 1;
+.resize:hover,
+.grid-item.resizing .resize {
+  opacity: 0.75;
   transform: scale(1.25);
   transition:
     opacity 0.15s,
-    transform 0.15s;
+    transform 0.15s cubic-bezier(0.34, 1.56, 0.64, 1);
 }
 
 .resize-left,

--- a/src/Grid.css
+++ b/src/Grid.css
@@ -1,3 +1,7 @@
+:root {
+  --transition-time: 0.15s;
+}
+
 .grid {
   position: relative;
   width: 100%;
@@ -8,8 +12,6 @@
   width: 100%;
   height: 100%;
   display: grid;
-  /*grid-template-rows: repeat(8, 1fr);
-  grid-template-columns: repeat(8, 1fr);*/
 }
 
 .grid-slot {
@@ -32,13 +34,13 @@
 
 .grid-slot:hover {
   padding: min(6px, 10%);
-  transition: padding 0.15s;
+  transition: padding var(--transition-time);
 }
 
 .grid-slot:hover .grid-slot-inner {
   border: 2px solid #fff6;
   background-color: #fff2;
-  transition: background-color 0.15s;
+  transition: background-color var(--transition-time);
 }
 
 .grid-items {
@@ -63,29 +65,35 @@
   height: 100%;
 
   transition:
-    transform 0.15s,
-    opacity 0.15s;
+    transform var(--transition-time),
+    opacity var(--transition-time);
+}
+
+.grid-item.resizing,
+.grid-item.dragging {
+  box-sizing: border-box;
+  z-index: 1;
+  opacity: 0.75;
+  /*background-color: #fff4;
+  border-radius: 12px;*/
 }
 
 .grid-item.resizing {
-  opacity: 0.75;
   transition:
-    width 0.15s,
-    height 0.15s,
-    opacity 0.15s;
+    width var(--transition-time),
+    height var(--transition-time),
+    opacity var(--transition-time);
   transition-timing-function: cubic-bezier(0.34, 1.56, 0.64, 1);
 }
 
 .grid-item.dragging {
   transform: scale(1.05);
-  opacity: 0.75;
   transition:
-    top 0.15s,
-    left 0.15s,
-    transform 0.15s,
-    opacity 0.15s;
+    top var(--transition-time),
+    left var(--transition-time),
+    transform var(--transition-time),
+    opacity var(--transition-time);
   transition-timing-function: cubic-bezier(0.34, 1.56, 0.64, 1);
-  z-index: 99;
 }
 
 .grid-item.invalid::after {
@@ -94,6 +102,7 @@
   width: 100%;
   height: 100%;
   background-color: #f004;
+  border-radius: 12px;
   pointer-events: none;
 }
 
@@ -103,8 +112,8 @@
   opacity: 0.5;
   position: absolute;
   transition:
-    opacity 0.15s,
-    transform 0.15s;
+    opacity var(--transition-time),
+    transform var(--transition-time);
 }
 
 .resize:hover,
@@ -112,8 +121,8 @@
   opacity: 0.75;
   transform: scale(1.25);
   transition:
-    opacity 0.15s,
-    transform 0.15s cubic-bezier(0.34, 1.56, 0.64, 1);
+    opacity var(--transition-time),
+    transform var(--transition-time) cubic-bezier(0.34, 1.56, 0.64, 1);
 }
 
 .resize-left,

--- a/src/Grid.css
+++ b/src/Grid.css
@@ -88,6 +88,15 @@
   z-index: 99;
 }
 
+.grid-item.invalid::after {
+  content: "";
+  position: absolute;
+  width: 100%;
+  height: 100%;
+  background-color: #f004;
+  pointer-events: none;
+}
+
 .resize {
   background-color: white;
   border-radius: 4px;

--- a/src/Grid.tsx
+++ b/src/Grid.tsx
@@ -24,6 +24,7 @@ interface GridContextType {
   width: number;
   height: number;
   cellSize: number;
+  items: Map<HTMLElement, { position: GridPosition; size: GridSize }>;
 }
 
 const GridContext = createContext<GridContextType>(null);
@@ -42,33 +43,70 @@ export function GridItem({
   children?: React.ReactNode;
 }) {
   const ref = useRef<HTMLDivElement>(null);
+  const ctx = useContext(GridContext);
+
   const [position, setPosition] = useState<GridPosition>(initialPosition);
   const [size, setSize] = useState<GridSize>(initialSize);
   const [dragging, setDragging] = useState(false);
   const [resizing, setResizing] = useState(false);
-  const ctx = useContext(GridContext);
+
+  const [lastPosition, setLastPosition] = useState<GridPosition>(position);
+  const [lastSize, setLastSize] = useState<GridSize>(size);
+  const [isValid, setIsValid] = useState(true);
+
+  useEffect(() => {
+    ctx.items.set(ref.current, { position: position, size: size });
+    verifyPosition();
+
+    return () => {
+      ctx.items.delete(ref.current);
+    };
+  }, [size, position, ref.current]);
 
   function pixelToGrid(x: number, y: number): [number, number] {
     return [Math.round(x / ctx.cellSize), Math.round(y / ctx.cellSize)];
   }
 
-  function handleDrag(x: number, y: number, dragging: boolean) {
+  function verifyPosition() {
+    let output = true;
+    ctx.items.forEach((state, el) => {
+      if (el === ref.current) return;
+
+      const overlapping =
+        position.gridX < state.position.gridX + state.size.width &&
+        position.gridX + size.width > state.position.gridX &&
+        position.gridY < state.position.gridY + state.size.height &&
+        position.gridY + size.height > state.position.gridY;
+
+      if (overlapping) output = false;
+    });
+    setIsValid(output);
+  }
+
+  function handleDrag(x: number, y: number, drag: boolean) {
     let [gridX, gridY] = pixelToGrid(x, y);
     gridX = Math.min(ctx.width - size.width, Math.max(0, gridX));
     gridY = Math.min(ctx.height - size.height, Math.max(0, gridY));
+
     setPosition({ gridX: gridX, gridY: gridY });
-    setDragging(dragging);
+    setDragging(drag);
+
+    if (isValid) {
+      setLastPosition(position);
+    } else if (!drag && dragging) {
+      setPosition(lastPosition);
+    }
   }
 
-  function handleResizeLeft(x: number, y: number, dragging: boolean) {
+  function handleResizeLeft(x: number, y: number, drag: boolean) {
     x -= ctx.cellSize / 2;
-    handleDrag(x, position.gridY * ctx.cellSize, dragging);
+    handleDrag(x, position.gridY * ctx.cellSize, drag);
   }
 
-  function handleResizeRight(x: number, y: number, dragging: boolean) {
+  function handleResizeRight(x: number, y: number, drag: boolean) {
     x += ctx.cellSize / 2;
     const [gridX, gridY] = pixelToGrid(x, y);
-    setResizing(dragging);
+    setResizing(drag);
 
     setSize({
       width: Math.min(
@@ -77,17 +115,23 @@ export function GridItem({
       ),
       height: size.height,
     });
+
+    if (isValid) {
+      setLastSize(size);
+    } else if (!drag && resizing) {
+      setSize(lastSize);
+    }
   }
 
-  function handleResizeUp(x: number, y: number, dragging: boolean) {
+  function handleResizeUp(x: number, y: number, drag: boolean) {
     y -= ctx.cellSize / 2;
-    handleDrag(position.gridX * ctx.cellSize, y, dragging);
+    handleDrag(position.gridX * ctx.cellSize, y, drag);
   }
 
-  function handleResizeDown(x: number, y: number, dragging: boolean) {
+  function handleResizeDown(x: number, y: number, drag: boolean) {
     y += ctx.cellSize / 2;
     const [gridX, gridY] = pixelToGrid(x, y);
-    setResizing(dragging);
+    setResizing(drag);
 
     setSize({
       width: size.width,
@@ -96,6 +140,12 @@ export function GridItem({
         Math.max(1, gridY - position.gridY),
       ),
     });
+
+    if (isValid) {
+      setLastSize(size);
+    } else if (!drag && resizing) {
+      setSize(lastSize);
+    }
   }
 
   return (
@@ -104,6 +154,7 @@ export function GridItem({
         styles.gridItem,
         dragging ? styles.dragging : "",
         resizing ? styles.resizing : "",
+        !isValid ? styles.invalid : "",
       ].join(" ")}
       style={{
         left: position.gridX * ctx.cellSize,
@@ -205,6 +256,7 @@ export function Grid({
             width: width,
             height: height,
             cellSize: cellSize,
+            items: new Map(),
           }}
         >
           {children}

--- a/src/Widget.tsx
+++ b/src/Widget.tsx
@@ -1,17 +1,26 @@
 import React from "react";
-import { GridSize, GridItem } from "./Grid";
+import { GridSize, GridItem, GridPosition } from "./Grid";
 import styles from "./Widget.css";
 
 export default function Widget({
-  size,
+  size = { width: 6, height: 4 },
+  position = { gridX: 0, gridY: 0 },
+  resizeable = true,
   children,
 }: {
-  size: GridSize;
+  size?: GridSize;
+  position?: GridPosition;
+  resizeable?: boolean;
   children: React.ReactNode;
 }) {
   return (
     <div className={styles.widget}>
-      <GridItem initialSize={size} initialPosition={{ gridX: 0, gridY: 0 }}>
+      <GridItem
+        resizeable={resizeable}
+        draggable={true}
+        initialSize={size}
+        initialPosition={position}
+      >
         {children}
       </GridItem>
     </div>

--- a/src/Widget.tsx
+++ b/src/Widget.tsx
@@ -17,7 +17,6 @@ export default function Widget({
     <div className={styles.widget}>
       <GridItem
         resizeable={resizeable}
-        draggable={true}
         initialSize={size}
         initialPosition={position}
       >

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,6 +2,7 @@
   "compilerOptions": {
     // "verbatimModuleSyntax": true,
     "jsx": "react",
-    "esModuleInterop": true
+    "esModuleInterop": true,
+    "target": "ES6"
   }
 }


### PR DESCRIPTION
## Todo:
- [ ] Add resizing for left and up directions
  - This requires keeping track of extra information. Currently, Widgets can be resized down and to the right.
- [ ] Disable Widgets during edit mode
  - Currently, buttons inside of a Widget can be clicked while dragging.