### PR TITLE
Disable widgets in edit mode

### DIFF
--- a/src/Grid.css
+++ b/src/Grid.css
@@ -92,6 +92,10 @@
   /*opacity var(--transition-time);*/
 }
 
+.grid-item.editing > div * {
+  pointer-events: none;
+}
+
 .grid-item.resizing,
 .grid-item.dragging {
   box-sizing: border-box;

--- a/src/Grid.tsx
+++ b/src/Grid.tsx
@@ -156,6 +156,7 @@ export function GridItem({
         styles.gridItem,
         dragging ? styles.dragging : "",
         resizing ? styles.resizing : "",
+        ctx.editing ? styles.editing : "",
         !isValid ? styles.invalid : "",
       ].join(" ")}
       style={{


### PR DESCRIPTION
This PR prevents mouse events from propagating to widgets while in edit mode.